### PR TITLE
docs: add Big Tech architecture blueprint and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Nextify.js é um framework open source inspirado no melhor ecossistema React mod
 4. **Distribuição contínua**: conteúdo técnico, benchmark transparente e comunidade ativa.
 5. **Release process confiável**: changelog rigoroso, semver e canary releases.
 
-> A estratégia completa está na pasta [`docs/`](./docs) e no guia de arquitetura [`ARCHITECTURE.md`](./ARCHITECTURE.md).
+> A estratégia completa está na pasta [`docs/`](./docs), no guia de arquitetura [`ARCHITECTURE.md`](./ARCHITECTURE.md) e no blueprint Big Tech [`docs/NEXTIFY_BIGTECH_BLUEPRINT.md`](./docs/NEXTIFY_BIGTECH_BLUEPRINT.md).
 
 ---
 

--- a/docs/NEXTIFY_BIGTECH_BLUEPRINT.md
+++ b/docs/NEXTIFY_BIGTECH_BLUEPRINT.md
@@ -1,0 +1,627 @@
+# Nextify.js — Big Tech Architecture Blueprint
+
+> Documento técnico completo para projetar, arquitetar, operar e escalar o **Nextify.js** como um framework React moderno, com foco em performance, modularidade, escala global e crescimento open source.
+
+---
+
+## 1) Visão geral do framework Nextify.js
+
+**Nextify.js** é um framework React/TypeScript orientado a:
+
+- **DX extrema**: setup simples, convenções claras, CLI produtiva.
+- **Performance por padrão**: SSR streaming, SSG, ISR, cache multicamadas.
+- **Escala global**: Edge + CDN + adapters multi-cloud.
+- **Arquitetura plugável**: núcleo pequeno e extensível.
+- **Pronto para produção**: segurança, observabilidade e governança de releases.
+
+### Objetivos de produto
+
+1. Superar o baseline de performance do ecossistema React server-first.
+2. Ser simples para iniciantes e poderoso para times enterprise.
+3. Permitir evolução rápida via monorepo + plugin system + RFC process.
+
+### Princípios de arquitetura
+
+- **Modular by design**: cada módulo pode evoluir independentemente.
+- **Contracts first**: APIs internas versionadas e tipadas.
+- **Edge aware**: decisões de runtime já consideram latência global.
+- **Secure by default**: políticas e middlewares de segurança nativos.
+- **Observable by default**: telemetria embutida em build/runtime.
+
+---
+
+## 2) Contribuição técnica de cada especialista do time
+
+### Principal Software Architect
+- Define boundaries entre CLI, core, runtime e adapters.
+- Garante estabilidade dos contratos internos (`manifest`, `plugin hooks`, `runtime API`).
+- Coordena RFCs para features críticas (router v2, cache v2, edge runtime).
+
+### React Core Engineer
+- Implementa renderer com React 18+ (`renderToPipeableStream` / `renderToReadableStream`).
+- Define hydration protocol e integração com Server Components (futuro).
+- Otimiza suspense boundaries, partial hydration e data fetching ergonomics.
+
+### JavaScript Compiler Engineer
+- Desenvolve pipeline baseado em **SWC/Rust** para transpile, transforms e minificação.
+- Cria plugin compiler API (tree-shaking hints, static analysis de rotas e data loaders).
+- Otimiza source maps, incremental compilation e cache de artefatos.
+
+### Web Performance Engineer
+- Define budgets de TTFB/LCP/INP e guardrails de performance.
+- Lidera image optimization, code splitting automático e prefetch inteligente.
+- Cria benchmarking contínuo vs Next.js/Remix/Astro em cenários reais.
+
+### DevOps / Infrastructure Engineer
+- Projeta deployment adapters (Node server, serverless, edge workers).
+- Define CI/CD, canary releases, rollout progressivo e rollback automático.
+- Implementa estratégia de cache distribuído, CDN e multi-region failover.
+
+### Security Engineer
+- Implementa middleware padrão: CSP, HSTS, X-Frame-Options, rate limiting.
+- Define secure defaults para API routes, cookies, secrets e SSR inputs.
+- Coordena SAST/Dependency Scanning, Security Advisories e disclosure policy.
+
+### Developer Experience Engineer
+- Constrói CLI (`create-nextify-app`) com templates, doctor command e upgrade assistant.
+- Define mensagens de erro acionáveis, docs guiadas por cenários e recipes.
+- Mantém integração IDE (types, snippets, lint presets).
+
+### Open Source Strategy Specialist
+- Estrutura governança, roadmap público e estratégia de comunidade.
+- Define trilha de contribuidor (good first issue → maintainer path).
+- Lidera posicionamento, conteúdo técnico e campanhas de adoção.
+
+---
+
+## 3) Arquitetura completa do framework
+
+### Diagrama conceitual (alto nível)
+
+```text
+                +-------------------------------+
+                |      create-nextify-app       |
+                |   CLI + templates + doctor    |
+                +---------------+---------------+
+                                |
+                                v
++------------------+   +------------------+   +------------------+
+|   Dev Server     |   |     Compiler     |   |      Builder      |
+| HMR + Fast Refresh|<->| SWC/Rust + Vite |<->| SSR/SSG/ISR output|
++---------+--------+   +---------+--------+   +---------+--------+
+          |                      |                        |
+          v                      v                        v
++---------------------------------------------------------------+
+|                           Core                                |
+| Router | Renderer | Middleware | Plugin Host | Cache API      |
++----------+------------+------------+-------------+------------+
+           |            |            |             |
+           v            v            v             v
+      Runtime Client  API Runtime  Edge Runtime  Deployment Adapters
+           |                          |
+           +------------ CDN + Global Edge ------------+
+```
+
+### Módulos centrais
+
+- **CLI**: scaffolding, comandos `dev/build/start`, diagnóstico.
+- **Router**: file-based routing + route manifest + middleware matching.
+- **Renderer**: SSR tradicional + streaming SSR + SSG/ISR render workers.
+- **Dev Server**: grafo de módulos em memória + HMR granular.
+- **Compiler**: TS/JSX transform, bundles por target (client/server/edge).
+- **Runtime Client**: hydration, router transitions, prefetch e cache client-side.
+- **Plugin System**: hooks em build/runtime/dev-server.
+- **Cache Layer**: memória local + Redis/KV distribuído + tag invalidation.
+- **Deployment Adapters**: Node, AWS Lambda, Cloudflare Workers, Vercel Edge.
+
+---
+
+## 4) Estrutura de diretórios recomendada
+
+```text
+nextify.js/
+  packages/
+    cli/
+    core/
+      src/
+        routing/
+        rendering/
+        middleware/
+        plugins/
+        cache/
+    compiler/
+    dev-server/
+    runtime-client/
+    adapters/
+      adapter-node/
+      adapter-aws-lambda/
+      adapter-cloudflare/
+  examples/
+    blog/
+    ecommerce-storefront/
+    saas-dashboard/
+  docs/
+    architecture/
+    guides/
+    api/
+    benchmarks/
+  scripts/
+  .changeset/
+```
+
+### Estrutura de app gerada pela CLI
+
+```text
+my-app/
+  src/
+    pages/
+      index.tsx
+      about.tsx
+      posts/[slug].tsx
+      api/health.ts
+    middleware.ts
+    plugins/
+    lib/
+  public/
+  nextify.config.ts
+  package.json
+```
+
+---
+
+## 5) Funcionamento do sistema de roteamento (file-based routing)
+
+### Regras
+
+- `pages/index.tsx` → `/`
+- `pages/about.tsx` → `/about`
+- `pages/posts/[slug].tsx` → `/posts/:slug`
+- `pages/docs/[...all].tsx` → catch-all `/docs/*`
+- `pages/api/*.ts` → API routes
+
+### Pipeline de roteamento
+
+1. Scanner de arquivos gera `route-manifest.json`.
+2. Compiler extrai metadados (SSR/SSG/ISR/middleware).
+3. Runtime usa trie/radix tree para matching O(k).
+4. Middleware chain é aplicada antes do handler final.
+
+### Exemplo de criação de páginas e roteamento
+
+```tsx
+// src/pages/index.tsx
+export default function HomePage() {
+  return <h1>Bem-vindo ao Nextify.js</h1>;
+}
+```
+
+```tsx
+// src/pages/posts/[slug].tsx
+export async function getServerSideProps({ params }: { params: { slug: string } }) {
+  return { props: { slug: params.slug } };
+}
+
+export default function PostPage({ slug }: { slug: string }) {
+  return <article>Post: {slug}</article>;
+}
+```
+
+---
+
+## 6) Motor de renderização SSR
+
+### Estratégias suportadas
+
+- **SSR**: render a cada request para dados dinâmicos.
+- **SSG**: render em build para rotas estáticas.
+- **ISR**: regeneração assíncrona com TTL por rota/tag.
+- **Streaming SSR**: flush inicial rápido + suspense boundaries.
+
+### Exemplo de renderização SSR (streaming)
+
+```ts
+// packages/core/src/rendering/ssrEngine.ts (conceitual)
+import { renderToPipeableStream } from 'react-dom/server';
+
+export function renderStreaming(App: React.FC, props: unknown, res: NodeJS.WritableStream) {
+  const { pipe } = renderToPipeableStream(<App {...(props as object)} />, {
+    bootstrapScripts: ['/assets/client.js'],
+    onShellReady() {
+      res.write('<!doctype html><html><body><div id="root">');
+      pipe(res);
+      res.write('</div></body></html>');
+    }
+  });
+}
+```
+
+### Decisão de modo por rota
+
+```ts
+mode = route.ssg ? 'SSG' : route.isr ? 'ISR' : 'SSR';
+```
+
+---
+
+## 7) Sistema de build e bundling
+
+### Stack recomendada
+
+- **Vite/Turbopack** para dev/build orchestration.
+- **SWC (Rust)** para transpile/minify/transforms.
+- **Esbuild** opcional para tarefas auxiliares ultra rápidas.
+
+### Saídas de build
+
+- `dist/client`: assets browser otimizados.
+- `dist/server`: bundle Node SSR/API.
+- `dist/edge`: bundle edge runtime (Web APIs).
+- `dist/manifest`: route manifest, chunk graph, cache metadata.
+
+### Otimizações do pipeline
+
+- Code splitting automático por rota + shared chunks.
+- Lazy loading inteligente por interações e viewport.
+- Asset hashing + long-term caching.
+- Preload/prefetch orientado por navegação preditiva.
+
+---
+
+## 8) Dev server e hot reload
+
+### Objetivos
+
+- Cold start < 500ms em apps médias.
+- HMR sub-100ms para alterações locais.
+- Invalidar somente módulos impactados (graph-aware invalidation).
+
+### Fluxo HMR
+
+1. File watcher detecta mudança.
+2. Compiler incremental recompila módulo alterado.
+3. HMR envia delta por websocket.
+4. Runtime client aplica patch sem full reload.
+
+### Recursos DX
+
+- Overlay de erro com stack mapeada por source maps.
+- `nextify doctor` para validar ambiente.
+- Logs estruturados com tracing de build steps.
+
+---
+
+## 9) CLI para criação de projetos
+
+### Comandos principais
+
+```bash
+npx create-nextify-app@latest my-app
+nextify dev
+nextify build
+nextify start
+nextify doctor
+```
+
+### Recursos da CLI
+
+- Templates (`blog`, `saas`, `ecommerce`, `minimal`).
+- Setup opcional de lint/test/formatter.
+- Detecção de package manager e lockfile.
+- Upgrade assistant para migrações de breaking changes.
+
+---
+
+## 10) Sistema de plugins
+
+### Contrato de plugin
+
+```ts
+export interface NextifyPlugin {
+  name: string;
+  setup?(ctx: PluginContext): void | Promise<void>;
+  hooks?: {
+    onConfigResolved?(config: NextifyConfig): void;
+    onRoutesGenerated?(routes: RouteDefinition[]): void;
+    onBuildStart?(): void;
+    onBuildEnd?(meta: BuildMetadata): void;
+    onRequest?(ctx: RequestContext): Promise<void> | void;
+  };
+}
+```
+
+### Exemplo de plugin
+
+```ts
+export default function pluginSecurityHeaders(): NextifyPlugin {
+  return {
+    name: 'plugin-security-headers',
+    hooks: {
+      onRequest(ctx) {
+        ctx.responseHeaders['x-content-type-options'] = 'nosniff';
+      }
+    }
+  };
+}
+```
+
+---
+
+## 11) Sistema de cache inteligente
+
+### Camadas de cache
+
+1. **L1 (in-process memory)**: latência mínima.
+2. **L2 (Redis/KV regional)**: compartilhado entre instâncias.
+3. **L3 (CDN edge cache)**: conteúdo próximo do usuário final.
+
+### Estratégias
+
+- Cache por rota, por query normalizada e por tags.
+- `stale-while-revalidate` em SSR/ISR.
+- Invalidação por evento (deploy, CMS webhook, mutation API).
+
+### Exemplo conceitual
+
+```ts
+await cache.set(
+  `page:${route}:${locale}`,
+  html,
+  { ttl: 60, tags: ['page', `route:${route}`], swr: 300 }
+);
+```
+
+---
+
+## 12) Otimização automática de performance
+
+- **Image optimization** com resize + formatos modernos (WebP/AVIF).
+- **Critical CSS extraction** e late-load de CSS não crítico.
+- **Script prioritization** (`defer`, `async`, `modulepreload`).
+- **Data prefetch inteligente** baseado em intenção do usuário.
+- **Bundle budget gates** em CI (falha build acima do orçamento).
+
+---
+
+## Exemplos de código pedidos
+
+### API Routes
+
+```ts
+// src/pages/api/health.ts
+export default function handler(_req: any, res: any) {
+  res.statusCode = 200;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify({ ok: true, service: 'nextify-app' }));
+}
+```
+
+### Middleware
+
+```ts
+// src/middleware.ts
+import type { NextifyMiddleware } from 'nextify';
+
+export const middleware: NextifyMiddleware = async (ctx, next) => {
+  ctx.responseHeaders['x-frame-options'] = 'DENY';
+  ctx.responseHeaders['x-nextify-region'] = ctx.region;
+  return next();
+};
+```
+
+---
+
+## Empacotar o framework como pacote NPM
+
+1. **Monorepo com workspaces** (`packages/*`).
+2. Build por pacote (`tsup/swc`), saída ESM + CJS + types.
+3. `exports` map por pacote para compatibilidade Node/TS.
+4. Versionamento com Changesets + SemVer.
+5. Publicação automatizada via GitHub Actions (`npm publish --provenance`).
+
+Exemplo de `package.json` (pacote core):
+
+```json
+{
+  "name": "@nextify/core",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist"]
+}
+```
+
+---
+
+## Escala para 100k a 1 milhão de usuários simultâneos
+
+### Arquitetura de infraestrutura escalável
+
+```text
+User
+  -> Anycast DNS
+  -> Global CDN (edge cache + WAF)
+  -> Edge Middleware (auth, geo, bot checks)
+  -> Regional Load Balancer
+  -> Stateless Nextify Runtime Pool (SSR/API)
+  -> Distributed Cache (Redis/KV)
+  -> Databases (read replicas + primary)
+  -> Async Queue / Event Bus
+```
+
+### Componentes críticos
+
+- **CDN global** para assets estáticos + páginas cacheáveis.
+- **Edge computing** para lógica de baixa latência (A/B, auth leve, redirects).
+- **Load balancing** L4/L7 com health checks ativos.
+- **Auto scaling** por CPU/RPS/latência p95.
+- **Cache distribuído** para SSR fragments e API hot paths.
+- **Rate limiting + WAF** para proteção volumétrica e OWASP.
+
+### Observabilidade e monitoramento
+
+- **Metrics**: RPS, p95/p99, error rate, cache hit ratio.
+- **Tracing**: OpenTelemetry fim a fim (edge → app → DB).
+- **Logs**: estruturados com correlação por request-id.
+- **SLOs**: ex. 99.9% de disponibilidade, p95 TTFB < 300ms em regiões-chave.
+
+### Estratégia de deploy global
+
+- Deploy blue/green com canary regional (1% → 10% → 50% → 100%).
+- Rollback automático por erro/latência acima do baseline.
+- Replicação multi-região ativa-ativa.
+- Invalidação de cache com versionamento de asset (`content hash`).
+
+### Fluxo de requisição da aplicação
+
+```text
+1) Browser requisita /posts/edge-caching
+2) CDN verifica cache key (path + locale + auth-variance)
+3) HIT: responde imediatamente
+4) MISS: encaminha para Edge Middleware
+5) Middleware aplica segurança, geolocalização e roteamento
+6) Runtime Nextify resolve rota no manifest
+7) Cache L2 consultado (ISR/SSR payload)
+8) Se miss, renderer executa SSR streaming + data fetch
+9) Resposta retorna, grava caches (L2 + CDN headers)
+10) Browser hidrata cliente e inicia prefetch inteligente
+```
+
+---
+
+## Estratégia para virar projeto open source viral no GitHub
+
+## 1. Estrutura ideal de repositório
+
+- `/packages`: código de produção modular.
+- `/examples`: casos reais prontos para rodar.
+- `/docs`: documentação versionada por release.
+- `/.github`: templates, workflows, automações de triagem.
+
+## 2. Organização de monorepo
+
+- Workspaces + task runner (Turborepo/Nx).
+- Ownership por pacote (`CODEOWNERS`).
+- Contratos internos testados por integration suites.
+
+## 3. Estratégia de documentação
+
+- Trilhas separadas: **Getting Started**, **Core Concepts**, **Deployment**, **Contributing**.
+- Páginas orientadas a tarefas reais (“como migrar do Next.js”, “como otimizar INP”).
+- Versão da docs por branch/release.
+
+## 4. README ideal para viralização
+
+- Valor em 30 segundos (proposta única).
+- Quickstart de 3 comandos.
+- Benchmarks transparentes.
+- GIF/demo curto mostrando DX + HMR.
+- CTA forte para star + Discord + “good first issue”.
+
+## 5. Guia de contribuição
+
+- Setup local em < 10 min.
+- Padrões de commit, testes e RFC para mudanças maiores.
+- Processo de review previsível e acolhedor.
+
+## 6. Roadmap público
+
+- Fases trimestrais, status público e donos por iniciativa.
+- Issues linkadas a milestones.
+- Atualizações mensais de progresso.
+
+## 7. Estratégia de releases
+
+- Canary semanal, stable quinzenal/mensal.
+- Changelog automatizado e semântico.
+- Breaking changes com migration guide.
+
+## 8. Estratégia de comunidade
+
+- GitHub Discussions para RFC e suporte.
+- Office hours mensais com maintainers.
+- Programa de embaixadores técnicos.
+
+## 9. Estratégia para atrair contribuidores
+
+- `good first issue` com escopo claro.
+- Mentoria em PR inicial.
+- Reconhecimento público em release notes.
+- Hackathons e bounty para features estratégicas.
+
+### Exemplos de projetos com Nextify.js
+
+- **Blog SEO-first** com ISR e MDX.
+- **E-commerce global** com edge personalization.
+- **SaaS dashboard** com autenticação, RBAC e streaming SSR.
+
+### Benchmarks recomendados
+
+- TTFB SSR p95 por região (US/EU/SA/APAC).
+- Tempo de build incremental em projeto médio/grande.
+- HMR latency média em alterações comuns.
+- Consumo de memória do dev server por 1k módulos.
+
+### Estrutura completa de documentação
+
+```text
+docs/
+  getting-started/
+  concepts/
+  architecture/
+  performance/
+  security/
+  deployment/
+  plugins/
+  api-reference/
+  migration/
+  contributing/
+  benchmarks/
+  roadmap/
+```
+
+---
+
+## Roadmap de evolução
+
+### v1 — Núcleo do framework
+- Router file-based + SSR/SSG + API routes.
+- Dev server rápido + HMR estável.
+- CLI e docs iniciais.
+
+### v2 — Edge runtime e plugins
+- Runtime edge oficial.
+- Plugin API estável com marketplace inicial.
+- Adapters multi-cloud.
+
+### v3 — Otimizações avançadas
+- Cache tags distribuídas + invalidação inteligente.
+- Partial hydration e otimizações de bundles por comportamento.
+- Ferramentas de profiling integradas.
+
+### v4 — Recursos inovadores (AI optimization)
+- AI-assisted prefetching e cache tuning.
+- AI bundle advisor (sugestões automáticas de splitting).
+- Auto-guardrails para performance regressions em PR.
+
+---
+
+## Conclusão
+
+O Nextify.js, seguindo este blueprint, nasce com fundamentos de **Big Tech engineering**:
+
+- arquitetura modular,
+- runtime performático,
+- escalabilidade global,
+- segurança e observabilidade enterprise,
+- e uma estratégia open source orientada a adoção massiva.
+
+Essa combinação permite evoluir de um framework emergente para uma plataforma de desenvolvimento web de referência.


### PR DESCRIPTION
### Motivation
- Provide a single comprehensive Big Tech–level architecture blueprint describing the design, modules and operational model for Nextify.js to guide implementation and contributors. 
- Capture scaling, deployment and observability guidance for high-traffic targets (100k–1M concurrent users) including CDN/edge, load balancing and cache strategies. 
- Surface an open-source growth strategy, repo/monorepo guidance and a phased roadmap (v1→v4) to accelerate adoption and contributor onboarding.

### Description
- Add a new detailed document at `docs/NEXTIFY_BIGTECH_BLUEPRINT.md` containing framework vision, specialist roles, modular architecture, file-based routing, SSR/streaming, SSG/ISR, build/bundling, dev server, plugin and cache designs, deployment adapters, examples and diagrams. 
- Update `README.md` to link to the new Big Tech blueprint alongside existing docs and architecture references. 
- The blueprint also includes practical examples (pages, dynamic routes, SSR, API routes, middleware), NPM packaging guidance and a global scale request flow to make the design actionable for implementers and operators.

### Testing
- Ran the project build with `npm run -s build`, which completed successfully and produced the build artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3995bf350832db93487d3ff5fa66e)