### PR TITLE
docs: corrigir README para uso do pacote nextify-monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > O framework React para times que querem velocidade de desenvolvimento, performance de produção e arquitetura extensível por padrão.
 
 [![CI](https://img.shields.io/github/actions/workflow/status/nextifyjs/nextify/ci.yml?branch=main)](#)
-[![npm version](https://img.shields.io/npm/v/nextify)](#)
+[![npm version](https://img.shields.io/npm/v/nextify-monorepo)](#)
 [![license](https://img.shields.io/github/license/nextifyjs/nextify)](#)
 [![Discord](https://img.shields.io/discord/000000000000000000?label=discord)](#)
 
@@ -136,18 +136,35 @@ SemVer + canary + changelog verificável em [`docs/RELEASE_STRATEGY.md`](./docs/
 
 ## Como começar
 
+Instale o framework publicado no npm:
+
 ```bash
-npm install
-npm run build
+npm install nextify-monorepo
 ```
 
-Para criar uma app:
+Crie um arquivo `index.js`:
+
+```js
+const nextify = require("nextify-monorepo");
+
+nextify.start({
+  port: 3000,
+});
+```
+
+Depois execute:
 
 ```bash
-npx create-nextify@latest minha-app
-cd minha-app
+node index.js
+```
+
+ou:
+
+```bash
 npm run dev
 ```
+
+> Queremos evoluir para um fluxo com CLI (`create-nextify-app`) para onboarding em uma linha, no estilo `npx create-nextify-app minha-app`.
 
 ## Comunidade
 


### PR DESCRIPTION
### Motivation

- Alinhar o quickstart do README com o pacote publicado no npm (`nextify-monorepo`) para evitar instruções divergentes.

### Description

- Atualiza o badge de versão npm para apontar para `nextify-monorepo` e reescreve a seção `Como começar` para `npm install nextify-monorepo`.
- Adiciona exemplo de uso com `require("nextify-monorepo")` e chamada `nextify.start({ port: 3000 })`, e ajusta comandos de execução para `node index.js` ou `npm run dev`.
- Mantém nota sobre evolução futura para CLI `create-nextify-app` para onboarding em uma linha.
- Skills: Nenhuma skill do sistema foi necessária pois a alteração é apenas de documentação.

### Testing

- Executado `git diff -- README.md` para validar as mudanças no arquivo e a diferença exibida corresponde às edições propostas.
- Conferido o conteúdo do README com `nl -ba README.md | sed -n '1,220p'` e o `package.json` com `nl -ba package.json` para confirmar que o nome do pacote é `nextify-monorepo` e que o quickstart foi atualizado com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43aab33f0832d98196afe14a4d49e)