### PR TITLE
test: add baseline Vitest suite for core, build and cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,9 @@
     "test": "npm run --workspaces --if-present test",
     "lint": "npm run --workspaces --if-present lint"
   },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^2.1.8",
+    "vitest": "^2.1.8"
+  },
   "description": "Nextify.js monorepo (public)"
 }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "node src/build.js",
     "typecheck": "node -e \"console.log('sem typecheck neste pacote')\"",
-    "test": "node -e \"console.log('sem testes neste pacote')\"",
+    "test": "vitest run --config ./vitest.config.ts",
     "lint": "node -e \"console.log('sem lint configurado neste pacote')\""
   }
 }

--- a/packages/build/src/build.js
+++ b/packages/build/src/build.js
@@ -1,7 +1,8 @@
 import { readdirSync, statSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-function collectJsAssets(dir) {
+export function collectJsAssets(dir) {
   try {
     return readdirSync(dir)
       .map((file) => join(dir, file))
@@ -12,7 +13,7 @@ function collectJsAssets(dir) {
   }
 }
 
-function evaluatePerformanceBudget(assets) {
+export function evaluatePerformanceBudget(assets) {
   const budget = {
     maxSingleAssetKb: 170,
     maxTotalJsKb: 350
@@ -39,17 +40,26 @@ function evaluatePerformanceBudget(assets) {
   };
 }
 
-mkdirSync('dist', { recursive: true });
+export function runBuild(cwd = process.cwd()) {
+  mkdirSync(join(cwd, 'dist'), { recursive: true });
 
-const routeManifest = {
-  generatedAt: new Date().toISOString(),
-  note: 'Manifesto de rotas gerado pelo build system do Nextify.'
-};
-writeFileSync('dist/route-manifest.json', JSON.stringify(routeManifest, null, 2));
+  const routeManifest = {
+    generatedAt: new Date().toISOString(),
+    note: 'Manifesto de rotas gerado pelo build system do Nextify.'
+  };
+  writeFileSync(join(cwd, 'dist/route-manifest.json'), JSON.stringify(routeManifest, null, 2));
 
-const assets = collectJsAssets(join(process.cwd(), 'dist'));
-const performanceBudget = evaluatePerformanceBudget(assets);
-writeFileSync('dist/performance-budget.json', JSON.stringify(performanceBudget, null, 2));
+  const assets = collectJsAssets(join(cwd, 'dist'));
+  const performanceBudget = evaluatePerformanceBudget(assets);
+  writeFileSync(join(cwd, 'dist/performance-budget.json'), JSON.stringify(performanceBudget, null, 2));
 
-console.log('Build concluído. Artefatos em dist/.');
-console.log(`Performance budget: ${performanceBudget.status.toUpperCase()}.`);
+  console.log('Build concluído. Artefatos em dist/.');
+  console.log(`Performance budget: ${performanceBudget.status.toUpperCase()}.`);
+
+  return performanceBudget;
+}
+
+const isDirectExecution = process.argv[1] === fileURLToPath(import.meta.url);
+if (isDirectExecution) {
+  runBuild();
+}

--- a/packages/build/tests/performanceBudget.test.ts
+++ b/packages/build/tests/performanceBudget.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { evaluatePerformanceBudget } from '../src/build.js';
+
+describe('evaluatePerformanceBudget', () => {
+  it('retorna pass sem violações dentro do budget', () => {
+    const result = evaluatePerformanceBudget([
+      { file: 'a.js', size: 100 * 1024 },
+      { file: 'b.js', size: 50 * 1024 }
+    ]);
+
+    expect(result.status).toBe('pass');
+    expect(result.violations).toHaveLength(0);
+    expect(result.totalKb).toBe(150);
+  });
+
+  it('retorna fail com violações quando excede limite', () => {
+    const result = evaluatePerformanceBudget([
+      { file: 'vendor.js', size: 200 * 1024 },
+      { file: 'app.js', size: 180 * 1024 }
+    ]);
+
+    expect(result.status).toBe('fail');
+    expect(result.violations.length).toBeGreaterThanOrEqual(2);
+    expect(result.largestAssetKb).toBe(200);
+    expect(result.totalKb).toBe(380);
+  });
+});

--- a/packages/build/vitest.config.ts
+++ b/packages/build/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts']
+  }
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "node -e \"console.log('build de demonstração concluído')\"",
     "typecheck": "node -e \"console.log('typecheck básico: sem validação TS estrita neste pacote')\"",
-    "test": "node -e \"console.log('sem testes neste pacote')\"",
+    "test": "vitest run --config ./vitest.config.ts",
     "lint": "node -e \"console.log('sem lint configurado neste pacote')\""
   }
 }

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const cliEntry = join(process.cwd(), 'dist/index.js');
+
+function runCli(args: string[], cwd: string) {
+  return spawnSync(process.execPath, [cliEntry, ...args], {
+    cwd,
+    encoding: 'utf-8'
+  });
+}
+
+describe('CLI smoke', () => {
+  it('create gera estrutura inicial de projeto', () => {
+    const root = mkdtempSync(join(tmpdir(), 'nextify-cli-create-'));
+    const projectName = 'my-app';
+
+    try {
+      const result = runCli(['create', projectName], root);
+
+      expect(result.status).toBe(0);
+      expect(existsSync(join(root, projectName, 'package.json'))).toBe(true);
+      expect(existsSync(join(root, projectName, 'pages', 'index.tsx'))).toBe(true);
+      expect(existsSync(join(root, projectName, 'pages', 'api', 'health.ts'))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('build gera manifesto em dist', () => {
+    const root = mkdtempSync(join(tmpdir(), 'nextify-cli-build-'));
+
+    try {
+      const result = runCli(['build'], root);
+      const manifestPath = join(root, 'dist', 'route-manifest.json');
+
+      expect(result.status).toBe(0);
+      expect(existsSync(manifestPath)).toBe(true);
+
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as {
+        note: string;
+      };
+      expect(manifest.note).toContain('Manifesto de rotas');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts']
+  }
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "node -e \"console.log('build de demonstração concluído')\"",
     "typecheck": "node -e \"console.log('typecheck básico: sem validação TS estrita neste pacote')\"",
-    "test": "node -e \"console.log('sem testes neste pacote')\"",
+    "test": "vitest run --config ./vitest.config.ts",
     "lint": "node -e \"console.log('sem lint configurado neste pacote')\""
   },
   "dependencies": {

--- a/packages/core/tests/composeMiddleware.test.ts
+++ b/packages/core/tests/composeMiddleware.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { composeMiddleware } from '../src/middleware/compose';
+
+describe('composeMiddleware', () => {
+  it('executa middlewares na ordem e retorna terminal', async () => {
+    const trace: string[] = [];
+    const run = composeMiddleware([
+      async (_req, next) => {
+        trace.push('m1:in');
+        const res = await next();
+        trace.push('m1:out');
+        return res;
+      },
+      async (_req, next) => {
+        trace.push('m2:in');
+        const res = await next();
+        trace.push('m2:out');
+        return res;
+      }
+    ]);
+
+    const response = await run(new Request('http://localhost/test'), async () => {
+      trace.push('terminal');
+      return new Response('ok');
+    });
+
+    expect(await response.text()).toBe('ok');
+    expect(trace).toEqual(['m1:in', 'm2:in', 'terminal', 'm2:out', 'm1:out']);
+  });
+
+  it('falha quando next é chamado múltiplas vezes', async () => {
+    const run = composeMiddleware([
+      async (_req, next) => {
+        await next();
+        return next();
+      }
+    ]);
+
+    await expect(run(new Request('http://localhost/err'), async () => new Response('ok'))).rejects.toThrow(
+      'next() chamado múltiplas vezes'
+    );
+  });
+});

--- a/packages/core/tests/executeLoader.integration.test.ts
+++ b/packages/core/tests/executeLoader.integration.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TaggedCache } from '../src/cache/taggedCache';
+import { executeLoader, invalidateDataTags } from '../src/data/runtime';
+
+describe('executeLoader integração com cache e tags', () => {
+  it('cache miss/hit e invalidação por tag', async () => {
+    const cache = new TaggedCache<unknown>();
+    const loaderSpy = vi.fn(async (ctx: { tag: (...values: string[]) => void }) => {
+      ctx.tag('products', 'inventory');
+      return { ts: Date.now() };
+    });
+
+    const request = new Request('http://localhost/products');
+
+    const first = await executeLoader(loaderSpy, request, undefined, {
+      cache,
+      cacheKey: 'products:list',
+      defaultRevalidateSeconds: 120
+    });
+
+    expect(first.source).toBe('origin');
+    expect(first.tags).toEqual(['products', 'inventory']);
+    expect(loaderSpy).toHaveBeenCalledTimes(1);
+
+    const second = await executeLoader(loaderSpy, request, undefined, {
+      cache,
+      cacheKey: 'products:list'
+    });
+
+    expect(second.source).toBe('cache');
+    expect(loaderSpy).toHaveBeenCalledTimes(1);
+
+    expect(invalidateDataTags(['products'], cache)).toBe(1);
+
+    const third = await executeLoader(loaderSpy, request, undefined, {
+      cache,
+      cacheKey: 'products:list'
+    });
+
+    expect(third.source).toBe('origin');
+    expect(loaderSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/tests/fileRouter.test.ts
+++ b/packages/core/tests/fileRouter.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { buildRouteManifest, toRoutePath } from '../src/routing/fileRouter';
+
+describe('fileRouter', () => {
+  it('converte caminhos para rotas estáticas e dinâmicas', () => {
+    expect(toRoutePath('pages/index.tsx')).toBe('/');
+    expect(toRoutePath('pages/blog/[slug].tsx')).toBe('/blog/:slug');
+    expect(toRoutePath('pages\\api\\users\\index.ts')).toBe('/api/users');
+  });
+
+  it('gera manifesto com tipo de rota', () => {
+    const manifest = buildRouteManifest([
+      'pages/index.tsx',
+      'pages/api/health.ts',
+      'pages/middleware.ts'
+    ]);
+
+    expect(manifest).toEqual([
+      { file: 'pages/index.tsx', routePath: '/', kind: 'page' },
+      { file: 'pages/api/health.ts', routePath: '/api/health', kind: 'api' },
+      { file: 'pages/middleware.ts', routePath: '/middleware', kind: 'middleware' }
+    ]);
+  });
+});

--- a/packages/core/tests/taggedCache.test.ts
+++ b/packages/core/tests/taggedCache.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TaggedCache } from '../src/cache/taggedCache';
+
+describe('TaggedCache', () => {
+  it('salva, lê e expira por ttl', () => {
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(1000);
+
+    const cache = new TaggedCache<string>();
+    cache.set('k1', 'valor', 500, ['a']);
+    expect(cache.get('k1')).toBe('valor');
+
+    nowSpy.mockReturnValue(1601);
+    expect(cache.get('k1')).toBeNull();
+    expect(cache.stats()).toEqual({ keys: 0, tags: 0 });
+
+    nowSpy.mockRestore();
+  });
+
+  it('invalida por tags e chave mantendo índice consistente', () => {
+    const cache = new TaggedCache<number>();
+    cache.set('a', 1, 60_000, ['t1', 'shared']);
+    cache.set('b', 2, 60_000, ['t2', 'shared']);
+
+    expect(cache.invalidateTag('t1')).toBe(1);
+    expect(cache.get('a')).toBeNull();
+    expect(cache.get('b')).toBe(2);
+
+    expect(cache.invalidateKey('b')).toBe(1);
+    expect(cache.invalidateTags(['shared', 'inexistente'])).toBe(0);
+    expect(cache.stats()).toEqual({ keys: 0, tags: 0 });
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary'],
+      include: ['src/**/*.ts'],
+      thresholds: {
+        lines: 60
+      }
+    }
+  }
+});


### PR DESCRIPTION
### Motivation
- Padronizar o framework de testes no monorepo e entregar um conjunto mínimo de testes por pacote (unitários no `@nextify/core`, avaliação de budget em `@nextify/build`, smoke em `@nextify/cli`).
- Garantir cobertura inicial mínima de linhas (60% em `@nextify/core`) para bloquear merges por falha de teste.
- Tornar partes do código testáveis exportando helpers onde fazia sentido (por exemplo no build). 

### Description
- Adicionei `vitest` e `@vitest/coverage-v8` como `devDependencies` no `package.json` raiz e alterei os scripts `test` em `@nextify/core`, `@nextify/build` e `create-nextify` para `vitest run --config ...`.
- Criei arquivos de configuração do Vitest por pacote (`packages/*/vitest.config.ts`) e configurei `coverage.thresholds.lines = 60` no `@nextify/core`.
- Implementei testes unitários em `@nextify/core` para `fileRouter`, `TaggedCache` e `composeMiddleware` e uma integração para `executeLoader` cobrindo cache miss/hit e invalidação de tags.
- Tornei `evaluatePerformanceBudget` e helpers testáveis em `packages/build/src/build.js` (exportando `evaluatePerformanceBudget`, `collectJsAssets` e `runBuild`) e adicionei testes de budget; também adicionei smoke tests CLI em `packages/cli/tests` para `create` e `build`.

### Testing
- Rodei `npm install` no ambiente e a instalação falhou devido a bloqueio no registro npm (`403 Forbidden`), impedindo a instalação de `vitest` e dependências relacionadas.
- Rodei `npm test` e a execução falhou porque o binário `vitest` não está disponível localmente (`sh: 1: vitest: not found`).
- Observação: os testes foram adicionados e validados sintaticamente; quando as dependências puderem ser instaladas em CI/dev (`npm install`), os testes devem executar e falhas de teste bloquearão merges conforme critério de aceite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6076d8884832dbc0d012004425880)