### PR TITLE
ci: implement canary release pipeline with manual latest promotion

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -1,0 +1,43 @@
+# Release notes template
+
+## Contexto
+
+- **Versão:** `vX.Y.Z`
+- **Canary de origem:** `canary-###`
+- **Data de release (UTC):** `YYYY-MM-DD HH:mm`
+- **Responsáveis (assinatura):** `@owner1, @owner2`
+
+## Highlights
+
+- Lista resumida das principais melhorias desta versão.
+
+## Breaking changes
+
+- [ ] Não há breaking changes.
+- [ ] Há breaking changes (detalhar abaixo).
+
+### Detalhes dos breaking changes
+
+1. Componente/API afetada:
+2. Mudança realizada:
+3. Impacto esperado:
+
+## Migração
+
+1. Pré-requisitos.
+2. Passo a passo de migração.
+3. Rollback recomendado.
+
+## Riscos conhecidos
+
+- Risco:
+  - Probabilidade:
+  - Impacto:
+  - Mitigação:
+
+## Checklist final
+
+- [ ] Changelog revisado e vinculado ao commit/tag.
+- [ ] Migração validada em ambiente staging.
+- [ ] Comunicação preparada (release notes públicas + canais internos).
+- [ ] Assinatura explícita dos responsáveis registrada.

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -1,0 +1,122 @@
+name: Release Canary
+
+on:
+  push:
+    branches:
+      - release/canary
+    tags:
+      - canary-v*
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  canary:
+    name: Build changelog + publish canary
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate traceable changelog entry
+        id: changelog
+        shell: bash
+        run: |
+          set -euo pipefail
+          PREVIOUS_TAG="$(git tag --list --sort=-creatordate 'v*' | head -n 1)"
+          if [ -n "$PREVIOUS_TAG" ]; then
+            RANGE="$PREVIOUS_TAG..HEAD"
+          else
+            RANGE="HEAD"
+          fi
+
+          NOTES="$(git log $RANGE --pretty=format:'- %s (%h) — %an' --no-merges)"
+          if [ -z "$NOTES" ]; then
+            NOTES='- Sem mudanças detectadas no intervalo selecionado.'
+          fi
+
+          DATE="$(date -u +'%Y-%m-%d')"
+          HEADER="## Canary ${DATE} (${GITHUB_SHA::7})"
+
+          {
+            printf '%s\n\n' "$HEADER"
+            printf 'Origem: `%s` em `%s`.\n\n' "$GITHUB_SHA" "$GITHUB_REF_NAME"
+            printf 'Responsável pelo publish: @%s.\n\n' "$GITHUB_ACTOR"
+            printf '### Mudanças\n%s\n\n' "$NOTES"
+          } > .changelog_entry.md
+
+          if [ -f CHANGELOG.md ]; then
+            cat CHANGELOG.md >> .changelog_previous.md
+          else
+            printf '# Changelog\n\n' > .changelog_previous.md
+          fi
+
+          {
+            printf '# Changelog\n\n'
+            cat .changelog_entry.md
+            if [ -f CHANGELOG.md ]; then
+              sed '1,2d' .changelog_previous.md
+            fi
+          } > CHANGELOG.md
+
+      - name: Commit changelog
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "Sem alteração em CHANGELOG.md"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "docs(changelog): update canary changelog"
+          git push
+
+      - name: Publish canary packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const { execSync } = require('node:child_process');
+          const fs = require('node:fs');
+          const path = require('node:path');
+
+          const root = process.cwd();
+          const packagePaths = fs
+            .readdirSync(path.join(root, 'packages'), { withFileTypes: true })
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => path.join(root, 'packages', entry.name, 'package.json'))
+            .filter((file) => fs.existsSync(file));
+
+          for (const packageJsonPath of packagePaths) {
+            const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+            const packageDir = path.dirname(packageJsonPath);
+            const cmd = `npm publish --tag canary --access public --provenance`;
+            console.log(`Publishing ${pkg.name} from ${packageDir}`);
+            execSync(cmd, { cwd: packageDir, stdio: 'inherit' });
+          }
+          NODE
+
+      - name: Publish prerelease notes
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: canary-${{ github.run_number }}
+          prerelease: true
+          target_commitish: ${{ github.sha }}
+          name: Canary ${{ github.run_number }}
+          body_path: .changelog_entry.md

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -1,0 +1,116 @@
+name: Promote Canary to Latest
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Versão estável que será promovida (ex: 1.4.0)'
+        required: true
+        type: string
+      source_tag:
+        description: 'Tag canary de origem (ex: canary-42)'
+        required: true
+        type: string
+      owners_signoff:
+        description: Responsáveis (usernames separados por vírgula)
+        required: true
+        type: string
+      checklist_tests:
+        description: Checklist - testes e benchmarks aprovados
+        required: true
+        type: boolean
+      checklist_changelog:
+        description: Checklist - changelog revisado
+        required: true
+        type: boolean
+      checklist_migration:
+        description: Checklist - notas de migração validadas
+        required: true
+        type: boolean
+      checklist_risks:
+        description: Checklist - riscos documentados e comunicados
+        required: true
+        type: boolean
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release checklist
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ "${{ inputs.checklist_tests }}" = "true" ] || (echo "Checklist de testes não aprovado" && exit 1)
+          [ "${{ inputs.checklist_changelog }}" = "true" ] || (echo "Checklist de changelog não aprovado" && exit 1)
+          [ "${{ inputs.checklist_migration }}" = "true" ] || (echo "Checklist de migração não aprovado" && exit 1)
+          [ "${{ inputs.checklist_risks }}" = "true" ] || (echo "Checklist de riscos não aprovado" && exit 1)
+          [ -n "${{ inputs.owners_signoff }}" ] || (echo "Assinatura dos responsáveis é obrigatória" && exit 1)
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Promote npm dist-tag from canary to latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGET_VERSION="${{ inputs.version }}"
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const { execSync } = require('node:child_process');
+
+          const version = process.env.TARGET_VERSION;
+          const packageDirs = fs
+            .readdirSync(path.join(process.cwd(), 'packages'), { withFileTypes: true })
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => path.join('packages', entry.name, 'package.json'))
+            .filter((file) => fs.existsSync(file));
+
+          for (const pkgPath of packageDirs) {
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+            const spec = `${pkg.name}@${version}`;
+            console.log(`Promoting ${spec} to latest`);
+            execSync(`npm dist-tag add ${spec} latest`, { stdio: 'inherit' });
+          }
+          NODE
+
+      - name: Create stable release notes
+        shell: bash
+        run: |
+          cat > release_notes.md <<'EOF'
+          ## Release v${{ inputs.version }}
+
+          **Canary de origem:** `${{ inputs.source_tag }}`
+          **Data de promoção (UTC):** `$(date -u +'%Y-%m-%d %H:%M:%S')`
+          **Responsáveis:** ${{ inputs.owners_signoff }}
+
+          ### Checklist de promoção
+          - [x] Testes e benchmarks aprovados
+          - [x] Changelog revisado
+          - [x] Notas de migração validadas
+          - [x] Riscos documentados/comunicados
+
+          Consulte o template padrão em `.github/release-notes-template.md` para o conteúdo detalhado de breaking changes, migração e riscos.
+          EOF
+
+      - name: Promote GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ inputs.version }}
+          target_commitish: ${{ github.sha }}
+          name: v${{ inputs.version }}
+          body_path: release_notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+Este arquivo é atualizado automaticamente pelo workflow de canary (`release-canary.yml`).

--- a/docs/RELEASE_STRATEGY.md
+++ b/docs/RELEASE_STRATEGY.md
@@ -12,20 +12,42 @@
 - `canary`: validação antecipada da comunidade.
 - `latest`: versão estável recomendada.
 
-## Cadência
+## Pipeline de release
 
-- Patch semanal (se necessário).
-- Minor mensal.
-- Major quando maturidade e migração estiverem claras.
+### 1) Canary automatizado (`.github/workflows/release-canary.yml`)
 
-## Checklist de release
+- Gatilho por branch dedicada (`release/canary`) ou tags `canary-v*`.
+- Geração automática de changelog rastreável em `CHANGELOG.md` com:
+  - hash de commit;
+  - branch/tag de origem;
+  - autor das mudanças;
+  - responsável pelo publish.
+- Publicação de todos os pacotes da monorepo no npm com `dist-tag` `canary`.
+- Criação de prerelease no GitHub com o mesmo conteúdo do changelog da execução.
 
-1. Testes e benchmarks aprovados.
-2. Changelog revisado.
-3. Notas de migração para breaking changes.
-4. Comunicação em múltiplos canais.
+### 2) Promoção manual para latest (`.github/workflows/release-promote.yml`)
+
+- Gatilho manual com `workflow_dispatch`.
+- Bloqueio por checklist obrigatório:
+  1. testes e benchmarks;
+  2. changelog revisado;
+  3. migração validada;
+  4. riscos documentados.
+- Campo obrigatório de assinatura de responsáveis (`owners_signoff`).
+- Promoção de `dist-tag` no npm para `latest` em todos os pacotes.
+- Publicação de release estável no GitHub com registro de origem canary e assinaturas.
+
+## Template de release notes
+
+- Arquivo padrão: `.github/release-notes-template.md`.
+- Seções obrigatórias:
+  - breaking changes;
+  - migração;
+  - riscos;
+  - assinatura de responsáveis.
 
 ## Qualidade de release
 
 - Nenhuma release sem documentação atualizada.
 - Nenhuma release major sem codemod/migração assistida.
+- Toda release deve possuir changelog rastreável e assinatura de responsáveis.


### PR DESCRIPTION
### Motivation
- Formalize a two-stage release pipeline to allow early community validation via a `canary` channel and a gated manual promotion to `latest` for stable releases.
- Ensure every release has a traceable changelog entry and an explicit responsible signoff to meet the acceptance criteria.
- Provide a standard release-notes template that enforces documenting breaking changes, migration steps and known risks.

### Description
- Added `.github/workflows/release-canary.yml` which triggers on `release/canary` branch and `canary-v*` tags, generates a traceable `CHANGELOG.md` entry (commit hash, origin ref, author, publisher) and publishes all workspace packages with `npm publish --tag canary` and creates a GitHub prerelease.
- Added `.github/workflows/release-promote.yml` which is `workflow_dispatch`-driven, requires checklist inputs and `owners_signoff`, promotes package `dist-tag`s from the provided version to `latest`, and creates a stable GitHub release using generated release notes.
- Added `.github/release-notes-template.md` providing the required sections for context, highlights, breaking changes, migration steps, risks and final checklist.
- Created a base `CHANGELOG.md` and updated `docs/RELEASE_STRATEGY.md` to document the new pipeline and the acceptance criteria (traceable changelog + responsible signatures).

### Testing
- Formatting check passed with `npx prettier --check .github/workflows/release-canary.yml .github/workflows/release-promote.yml .github/release-notes-template.md docs/RELEASE_STRATEGY.md CHANGELOG.md`.
- Linting passed with `npm run lint`.
- Files were committed after validation and are included in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6e580860c832da2c1d962243530d6)