### PR TITLE
feat(security): runtime CSP profiles, plugin-system limits, and runtime OWASP checklist

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,3 +46,9 @@ Critical and release-blocking findings must be remediated or explicitly risk-acc
 - Average **PR lead time (open → merge)**: **< 48h**
 - **CI success rate**: **> 85%**
 - **0 merges without tests** (test workflow is mandatory)
+
+## Runtime Hardening and Release Controls
+
+- CSP now supports profile-based rollout (`development` report-only; `balanced`/`strict` enforce by default).
+- OWASP runtime checklist for API routes/middleware/plugins lives at `docs/SECURITY_RUNTIME_CHECKLIST.md`.
+- Every **minor** release must include the completed checklist and migration notes when applicable.

--- a/docs/RELEASE_STRATEGY.md
+++ b/docs/RELEASE_STRATEGY.md
@@ -51,3 +51,9 @@
 - Nenhuma release sem documentação atualizada.
 - Nenhuma release major sem codemod/migração assistida.
 - Toda release deve possuir changelog rastreável e assinatura de responsáveis.
+
+## Gate de segurança para releases minor
+
+- Toda release `minor` deve anexar o checklist `docs/SECURITY_RUNTIME_CHECKLIST.md` preenchido nas release notes.
+- Itens sem evidência bloqueiam promoção para `latest`, exceto com aceite explícito de risco pelos responsáveis.
+- Quando houver mudança com impacto operacional, incluir notas de migração obrigatórias.

--- a/docs/SECURITY_RUNTIME_CHECKLIST.md
+++ b/docs/SECURITY_RUNTIME_CHECKLIST.md
@@ -1,0 +1,54 @@
+# Checklist de Segurança Runtime (OWASP) — Nextify.js
+
+> Aplicação: API routes, middleware e extensões via plugin system.
+> 
+> Obrigatório: anexar este checklist preenchido em **toda release minor**.
+
+## Como usar na release
+
+1. Copiar este checklist para as release notes.
+2. Marcar cada item com evidência (PR, teste, log, dashboard).
+3. Se houver exceção, documentar risco residual, owner e prazo de correção.
+
+---
+
+## A) API routes (OWASP API Security Top 10)
+
+- [ ] **API1 — BOLA**: validação de autorização por recurso (não confiar em IDs enviados pelo cliente).
+- [ ] **API2 — Broken Authentication**: tokens com expiração/rotação e validação de assinatura.
+- [ ] **API3 — Excessive Data Exposure**: resposta apenas com campos necessários (sem dados sensíveis).
+- [ ] **API4 — Lack of Resources & Rate Limiting**: limites por IP/chave e timeouts definidos.
+- [ ] **API5 — Broken Function Level Authorization**: checagem explícita por ação/role.
+- [ ] **API7 — Security Misconfiguration**: headers de segurança ativos e ambiente sem segredos hardcoded.
+- [ ] **API8 — Injection**: validação/sanitização de entrada e uso de APIs seguras de acesso a dados.
+- [ ] **API10 — Unsafe Consumption of APIs**: validação de respostas upstream e timeouts/retries controlados.
+
+## B) Middleware
+
+- [ ] CSP configurado por perfil (`development` report-only; `balanced|strict` enforce por padrão).
+- [ ] `X-Frame-Options`, `X-Content-Type-Options` e `Referrer-Policy` ativos.
+- [ ] Fluxo de erro evita leak de stack trace em produção.
+- [ ] Middleware idempotente e sem chamar `next()` múltiplas vezes.
+- [ ] Correlação de request-id em logs para investigação de incidentes.
+
+## C) Plugin system (superfície de ataque)
+
+- [ ] Plugins com nome único, não vazio e rastreável em logs.
+- [ ] Hooks permitidos por contrato fechado (allowlist), sem nomes arbitrários.
+- [ ] Limite de hooks por plugin para reduzir risco de abuso.
+- [ ] Limite global de plugins carregados por runtime.
+- [ ] Documentação de capacidade: plugin não recebe acesso implícito a segredos/processo.
+
+## D) Operação e resposta
+
+- [ ] Simulado de incidente executado no último ciclo (meta MTTR < 2h).
+- [ ] Taxa de regressão por release monitorada (meta < 5%).
+- [ ] Release com notas de migração quando aplicável (meta 100%).
+
+## Evidências da release
+
+- Versão:
+- Data:
+- Responsáveis:
+- Links (PRs/tests/dashboards):
+- Exceções e plano de ação:

--- a/packages/core/src/middleware/securityHeaders.ts
+++ b/packages/core/src/middleware/securityHeaders.ts
@@ -1,12 +1,55 @@
 import type { NextifyMiddleware } from './compose.js';
 
-export const securityHeaders: NextifyMiddleware = async (_req, next) => {
-  const response = await next();
+export type CspMode = 'enforce' | 'report-only';
 
-  response.headers.set('X-Frame-Options', 'DENY');
-  response.headers.set('X-Content-Type-Options', 'nosniff');
-  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-  response.headers.set('Content-Security-Policy', "default-src 'self'");
+export type SecurityProfile = 'development' | 'balanced' | 'strict';
 
-  return response;
+export type SecurityHeadersOptions = {
+  profile?: SecurityProfile;
+  cspMode?: CspMode;
+  cspDirectives?: string[];
+  cspReportUri?: string;
 };
+
+const PROFILE_CSP: Record<SecurityProfile, string[]> = {
+  development: ["default-src 'self'", "script-src 'self' 'unsafe-eval' 'unsafe-inline'", "style-src 'self' 'unsafe-inline'"],
+  balanced: ["default-src 'self'", "script-src 'self'", "style-src 'self' 'unsafe-inline'", "img-src 'self' data:", "connect-src 'self'"],
+  strict: ["default-src 'self'", "script-src 'self'", "style-src 'self'", "img-src 'self'", "connect-src 'self'", "object-src 'none'", "base-uri 'none'", "frame-ancestors 'none'", "form-action 'self'"]
+};
+
+export function createSecurityHeaders(options: SecurityHeadersOptions = {}): NextifyMiddleware {
+  const profile = options.profile ?? 'balanced';
+  const cspMode = options.cspMode ?? (profile === 'development' ? 'report-only' : 'enforce');
+  const directives = options.cspDirectives ?? PROFILE_CSP[profile];
+
+  if (directives.length === 0) {
+    throw new Error('CSP precisa ter ao menos uma diretiva');
+  }
+
+  const cspValue = [
+    ...directives,
+    options.cspReportUri ? `report-uri ${options.cspReportUri}` : ''
+  ]
+    .filter(Boolean)
+    .join('; ');
+
+  return async (_req, next) => {
+    const response = await next();
+
+    response.headers.set('X-Frame-Options', 'DENY');
+    response.headers.set('X-Content-Type-Options', 'nosniff');
+    response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+
+    if (cspMode === 'report-only') {
+      response.headers.set('Content-Security-Policy-Report-Only', cspValue);
+      response.headers.delete('Content-Security-Policy');
+    } else {
+      response.headers.set('Content-Security-Policy', cspValue);
+      response.headers.delete('Content-Security-Policy-Report-Only');
+    }
+
+    return response;
+  };
+}
+
+export const securityHeaders = createSecurityHeaders();

--- a/packages/core/src/plugins/pluginSystem.ts
+++ b/packages/core/src/plugins/pluginSystem.ts
@@ -1,16 +1,60 @@
-export type NextifyPlugin = {
-  name: string;
-  setup: (ctx: { hooks: Map<string, Array<() => void>> }) => void;
+export type NextifyHookName = 'beforeRequest' | 'afterResponse' | 'buildStart' | 'buildEnd';
+
+export type NextifyPluginContext = {
+  registerHook: (hook: NextifyHookName, handler: () => void) => void;
 };
 
-export class PluginSystem {
-  private hooks = new Map<string, Array<() => void>>();
+export type NextifyPlugin = {
+  name: string;
+  setup: (ctx: NextifyPluginContext) => void;
+};
 
-  use(plugin: NextifyPlugin) {
-    plugin.setup({ hooks: this.hooks });
+export type PluginSystemOptions = {
+  maxPlugins?: number;
+  maxHooksPerPlugin?: number;
+};
+
+const VALID_HOOKS: NextifyHookName[] = ['beforeRequest', 'afterResponse', 'buildStart', 'buildEnd'];
+
+export class PluginSystem {
+  private hooks = new Map<NextifyHookName, Array<() => void>>();
+  private plugins = new Set<string>();
+  private readonly maxPlugins: number;
+  private readonly maxHooksPerPlugin: number;
+
+  constructor(options: PluginSystemOptions = {}) {
+    this.maxPlugins = options.maxPlugins ?? 30;
+    this.maxHooksPerPlugin = options.maxHooksPerPlugin ?? 10;
   }
 
-  runHook(name: string) {
+  use(plugin: NextifyPlugin) {
+    const name = plugin.name.trim();
+    if (!name) throw new Error('Plugin precisa ter nome não vazio');
+    if (this.plugins.has(name)) throw new Error(`Plugin duplicado: ${name}`);
+    if (this.plugins.size >= this.maxPlugins) throw new Error('Limite máximo de plugins excedido');
+
+    let registeredHooks = 0;
+
+    plugin.setup({
+      registerHook: (hook, handler) => {
+        if (!VALID_HOOKS.includes(hook)) throw new Error(`Hook inválido: ${hook}`);
+        if (registeredHooks >= this.maxHooksPerPlugin) {
+          throw new Error(`Plugin ${name} excedeu limite de hooks (${this.maxHooksPerPlugin})`);
+        }
+
+        const entries = this.hooks.get(hook) ?? [];
+        entries.push(handler);
+        this.hooks.set(hook, entries);
+        registeredHooks += 1;
+      }
+    });
+
+    this.plugins.add(name);
+  }
+
+  runHook(name: NextifyHookName) {
+    if (!VALID_HOOKS.includes(name)) throw new Error(`Hook inválido: ${name}`);
+
     const entries = this.hooks.get(name) ?? [];
     for (const fn of entries) fn();
   }

--- a/packages/core/tests/pluginSystem.test.ts
+++ b/packages/core/tests/pluginSystem.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { PluginSystem } from '../src/plugins/pluginSystem';
+
+describe('PluginSystem', () => {
+  it('registra e executa hooks válidos', () => {
+    const runtime = new PluginSystem();
+    const trace: string[] = [];
+
+    runtime.use({
+      name: 'logger',
+      setup: ({ registerHook }) => {
+        registerHook('beforeRequest', () => trace.push('before'));
+        registerHook('afterResponse', () => trace.push('after'));
+      }
+    });
+
+    runtime.runHook('beforeRequest');
+    runtime.runHook('afterResponse');
+
+    expect(trace).toEqual(['before', 'after']);
+  });
+
+  it('bloqueia plugin duplicado', () => {
+    const runtime = new PluginSystem();
+
+    runtime.use({
+      name: 'dupe',
+      setup: () => {}
+    });
+
+    expect(() =>
+      runtime.use({
+        name: 'dupe',
+        setup: () => {}
+      })
+    ).toThrow('Plugin duplicado: dupe');
+  });
+
+  it('bloqueia hook inválido e excesso de hooks por plugin', () => {
+    const runtime = new PluginSystem({ maxHooksPerPlugin: 1 });
+
+    expect(() =>
+      runtime.use({
+        name: 'invalid',
+        setup: ({ registerHook }) => {
+          registerHook('beforeRequest', () => {});
+          registerHook('buildEnd', () => {});
+        }
+      })
+    ).toThrow('Plugin invalid excedeu limite de hooks (1)');
+
+    expect(() =>
+      runtime.use({
+        name: 'bad-hook',
+        setup: ({ registerHook }) => {
+          registerHook('not-exists' as never, () => {});
+        }
+      })
+    ).toThrow('Hook inválido: not-exists');
+  });
+});

--- a/packages/core/tests/securityHeaders.test.ts
+++ b/packages/core/tests/securityHeaders.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { createSecurityHeaders } from '../src/middleware/securityHeaders';
+
+describe('securityHeaders', () => {
+  it('usa enforce por padrão no perfil balanced', async () => {
+    const middleware = createSecurityHeaders({ profile: 'balanced' });
+    const response = await middleware(new Request('http://localhost/'), async () => new Response('ok'));
+
+    expect(response.headers.get('Content-Security-Policy')).toContain("default-src 'self'");
+    expect(response.headers.get('Content-Security-Policy-Report-Only')).toBeNull();
+  });
+
+  it('usa report-only automaticamente no perfil development', async () => {
+    const middleware = createSecurityHeaders({ profile: 'development' });
+    const response = await middleware(new Request('http://localhost/'), async () => new Response('ok'));
+
+    expect(response.headers.get('Content-Security-Policy-Report-Only')).toContain("script-src 'self' 'unsafe-eval' 'unsafe-inline'");
+    expect(response.headers.get('Content-Security-Policy')).toBeNull();
+  });
+
+  it('aceita report-uri no valor de CSP', async () => {
+    const middleware = createSecurityHeaders({
+      profile: 'strict',
+      cspMode: 'report-only',
+      cspReportUri: '/api/security/csp-report'
+    });
+
+    const response = await middleware(new Request('http://localhost/'), async () => new Response('ok'));
+
+    expect(response.headers.get('Content-Security-Policy-Report-Only')).toContain('report-uri /api/security/csp-report');
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a safer runtime posture by enabling profile-driven CSP rollout (report-only → enforce) to allow staged deployments.
- Reduce plugin-surface risk by enforcing a contract and resource limits for plugins and hooks.
- Ensure every `minor` release includes an OWASP-based runtime security checklist to certify API/middleware/plugin hygiene.

### Description

- Introduced `createSecurityHeaders` in `packages/core/src/middleware/securityHeaders.ts` with `profile` (`development|balanced|strict`), `cspMode` (`report-only|enforce`), `cspDirectives`, and `cspReportUri` and exported `securityHeaders = createSecurityHeaders()` as default middleware.
- Hardened the plugin system in `packages/core/src/plugins/pluginSystem.ts` by adding a `registerHook` API, a hook allowlist (`beforeRequest`, `afterResponse`, `buildStart`, `buildEnd`), duplicate-name protection, and configurable `maxPlugins` and `maxHooksPerPlugin` limits.
- Added unit tests in `packages/core/tests/securityHeaders.test.ts` and `packages/core/tests/pluginSystem.test.ts` covering CSP profiles, `report-uri`, hook registration, duplicate plugin detection, invalid hooks, and hook limit enforcement.
- Added `docs/SECURITY_RUNTIME_CHECKLIST.md` with an OWASP-oriented checklist for API routes, middleware, and plugin surface, and updated `SECURITY.md` and `docs/RELEASE_STRATEGY.md` to require attaching the completed checklist to every `minor` release.

### Testing

- Ran `npm test --workspace @nextify/core` and all tests passed (`Test Files 7 passed`, `Tests 15 passed`).
- Ran `npm run build --workspace @nextify/core` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6ea4f34fc832dba4f6b808b5c9338)