### PR TITLE
Sanitize reliability artifacts and add secret-file .gitignore entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Performance regression gate (baseline)
         run: npm run benchmark:regression
 
-      - name: Production reliability feedback loop (real traffic gate)
+      - name: Production reliability feedback loop (aggregated route gate)
         run: npm run reliability:production-gate
 
       - name: DORA metrics gate

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ artifacts/dora/*
 !artifacts/dora/targets.v1.json
 dist/
 .nextify/
+.env
+.env.*
+!.env.example
+*.pem
+*.key

--- a/artifacts/health/engineering-health-panel.json
+++ b/artifacts/health/engineering-health-panel.json
@@ -1,13 +1,13 @@
 {
   "generatedAt": "2026-03-22T17:34:57.883Z",
   "sources": {
-    "benchmarkPath": "/workspace/Nextify.js/artifacts/benchmarks/synthetic-benchmark.latest.json",
-    "baselinePath": "/workspace/Nextify.js/artifacts/benchmarks/synthetic-benchmark.baseline.v1.json",
-    "traceabilityPath": "/workspace/Nextify.js/artifacts/sbom/traceability.json",
-    "performanceBudgetPath": "/workspace/Nextify.js/packages/build/dist/performance-budget.json",
-    "auditPath": "/workspace/Nextify.js/docs/reliability-reports/latest-internal-audit.md",
-    "productionFeedbackPath": "/workspace/Nextify.js/artifacts/observability/production-feedback-report.latest.json",
-    "doraMetricsPath": "/workspace/Nextify.js/artifacts/dora/metrics.latest.json"
+    "benchmarkPath": "artifacts/benchmarks/synthetic-benchmark.latest.json",
+    "baselinePath": "artifacts/benchmarks/synthetic-benchmark.baseline.v1.json",
+    "traceabilityPath": "artifacts/sbom/traceability.json",
+    "performanceBudgetPath": "packages/build/dist/performance-budget.json",
+    "auditPath": "docs/reliability-reports/latest-internal-audit.md",
+    "productionFeedbackPath": "artifacts/observability/production-feedback-report.latest.json",
+    "doraMetricsPath": "artifacts/dora/metrics.latest.json"
   },
   "summary": {
     "syntheticBenchmarkStatus": "pass",

--- a/artifacts/observability/production-feedback-report.latest.json
+++ b/artifacts/observability/production-feedback-report.latest.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-03-22T17:34:57.084Z",
+  "generatedAt": "2026-08-13T04:02:45.239Z",
   "source": {
-    "trafficPath": "/workspace/Nextify.js/artifacts/observability/production-traffic.latest.json",
-    "thresholdsPath": "/workspace/Nextify.js/artifacts/observability/production-thresholds.v1.json"
+    "trafficPath": "artifacts/observability/production-traffic.latest.json",
+    "thresholdsPath": "artifacts/observability/production-thresholds.v1.json"
   },
   "status": "pass",
   "summary": {

--- a/artifacts/observability/production-thresholds.v1.json
+++ b/artifacts/observability/production-thresholds.v1.json
@@ -1,6 +1,6 @@
 {
   "version": "v1",
-  "description": "Thresholds de produção para blindagem de latência/TTFB em tráfego real.",
+  "description": "Thresholds de confiabilidade para dados agregados e anonimizados por rota.",
   "routes": [
     {
       "routeId": "ssr-home",

--- a/docs/NEXTIFY_TECHNICAL_ASSESSMENT_GAP_CHECK_2026-03-22.md
+++ b/docs/NEXTIFY_TECHNICAL_ASSESSMENT_GAP_CHECK_2026-03-22.md
@@ -83,14 +83,14 @@ O diagnóstico técnico do documento descreve três gaps principais (release eng
 
 ## 4) Itens parcialmente criados ou ainda com gap
 
-### 4.1 “Feedback loop” de confiabilidade orientado a produção real
+### 4.1 “Feedback loop” de confiabilidade orientado por dados agregados
 - **Status:** ✅ Criado
-- **Leitura:** além do benchmark sintético, agora há gate dedicado de tráfego real para bloquear regressões de latência/TTFB e taxa de erro por rota crítica.
+- **Leitura:** além do benchmark sintético, agora há gate dedicado de dados agregados/anonimizados de rota para bloquear regressões de latência/TTFB e taxa de erro por rota crítica.
 - **Evidência:**
   - Script `reliability:production-gate` no `package.json`.
   - Implementação em `scripts/run-production-feedback-gate.mjs`.
   - Thresholds versionados em `artifacts/observability/production-thresholds.v1.json`.
-  - Snapshot de tráfego real em `artifacts/observability/production-traffic.latest.json`.
+  - Snapshot agregado e anonimizado em `artifacts/observability/production-traffic.latest.json`.
   - Execução no CI (`Production reliability feedback loop`) em `.github/workflows/ci.yml`.
 
 ### 4.2 Métricas de sucesso DORA operacionalizadas automaticamente

--- a/docs/PLANO_DIFERENCIACAO_NEXTIFY_2026-03-29.md
+++ b/docs/PLANO_DIFERENCIACAO_NEXTIFY_2026-03-29.md
@@ -61,7 +61,7 @@
 
 ## Nextify Autopilot (core differentiator)
 
-**Proposta:** transformar o framework em um sistema que **otimiza a aplicação automaticamente com base em tráfego real**, em vez de depender de tuning manual.
+**Proposta:** transformar o framework em um sistema que **otimiza a aplicação automaticamente com base em sinais agregados e anonimizados de tráfego**, em vez de depender de tuning manual.
 
 ### Como funcionaria
 

--- a/docs/SLOS_AND_PERFORMANCE_BUDGET.md
+++ b/docs/SLOS_AND_PERFORMANCE_BUDGET.md
@@ -62,12 +62,12 @@ Template padrão: `docs/reliability-reports/REPORT_TEMPLATE.md`.
 - A metodologia aberta e reproduzível está em `docs/OPEN_BENCHMARK_METHODOLOGY.md` com pré-requisitos, comandos e limitações declaradas.
 - O relatório comparativo deve acompanhar release candidates para validação externa.
 
-## 7) Feedback loop de produção real (latência/TTFB/error rate)
+## 7) Feedback loop de confiabilidade com dados agregados (latência/TTFB/error rate)
 
 - Thresholds operacionais ficam versionados em `artifacts/observability/production-thresholds.v1.json`.
-- Snapshot de tráfego real é consolidado em `artifacts/observability/production-traffic.latest.json`.
+- Snapshot agregado e anonimizado por rota é consolidado em `artifacts/observability/production-traffic.latest.json`.
 - O script `npm run reliability:production-gate` compara p95 de TTFB/latência e taxa de erro das rotas críticas contra os thresholds.
-- O gate roda no CI (`Production reliability feedback loop`) e bloqueia merge quando houver regressão em tráfego real.
+- O gate roda no CI (`Production reliability feedback loop`) e bloqueia merge quando houver regressão nos dados agregados de rota.
 
 ## 8) Métricas DORA automatizadas
 

--- a/scripts/generate-engineering-health-panel.mjs
+++ b/scripts/generate-engineering-health-panel.mjs
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 
 const cwd = process.cwd();
 
@@ -24,6 +24,7 @@ const performanceBudgetPath = join(cwd, 'packages', 'build', 'dist', 'performanc
 const auditPath = join(cwd, 'docs', 'reliability-reports', 'latest-internal-audit.md');
 const productionFeedbackPath = join(cwd, 'artifacts', 'observability', 'production-feedback-report.latest.json');
 const doraMetricsPath = join(cwd, 'artifacts', 'dora', 'metrics.latest.json');
+const displayPath = (path) => relative(cwd, path);
 
 const missing = [benchmarkPath, baselinePath, traceabilityPath, performanceBudgetPath, auditPath, productionFeedbackPath, doraMetricsPath].filter(
   (path) => !existsSync(path),
@@ -64,13 +65,13 @@ const scenarioRows = benchmark.scenarios.map((scenario) => {
 const payload = {
   generatedAt: new Date().toISOString(),
   sources: {
-    benchmarkPath,
-    baselinePath,
-    traceabilityPath,
-    performanceBudgetPath,
-    auditPath,
-    productionFeedbackPath,
-    doraMetricsPath,
+    benchmarkPath: displayPath(benchmarkPath),
+    baselinePath: displayPath(baselinePath),
+    traceabilityPath: displayPath(traceabilityPath),
+    performanceBudgetPath: displayPath(performanceBudgetPath),
+    auditPath: displayPath(auditPath),
+    productionFeedbackPath: displayPath(productionFeedbackPath),
+    doraMetricsPath: displayPath(doraMetricsPath),
   },
   summary: {
     syntheticBenchmarkStatus: benchmark.status,

--- a/scripts/run-production-feedback-gate.mjs
+++ b/scripts/run-production-feedback-gate.mjs
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 
 const cwd = process.cwd();
 
@@ -10,6 +10,7 @@ function readJson(path) {
 const trafficPath = join(cwd, 'artifacts', 'observability', 'production-traffic.latest.json');
 const thresholdsPath = join(cwd, 'artifacts', 'observability', 'production-thresholds.v1.json');
 const outputPath = join(cwd, 'artifacts', 'observability', 'production-feedback-report.latest.json');
+const displayPath = (path) => relative(cwd, path);
 
 if (!existsSync(trafficPath) || !existsSync(thresholdsPath)) {
   console.error('Dados de produção ausentes para o feedback loop.');
@@ -63,8 +64,8 @@ const failures = checks.filter((check) => check.status === 'fail');
 const report = {
   generatedAt: new Date().toISOString(),
   source: {
-    trafficPath,
-    thresholdsPath,
+    trafficPath: displayPath(trafficPath),
+    thresholdsPath: displayPath(thresholdsPath),
   },
   status: failures.length === 0 ? 'pass' : 'fail',
   summary: {
@@ -77,7 +78,7 @@ const report = {
 writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`);
 
 if (failures.length > 0) {
-  console.error('Feedback loop de produção falhou: regressões detectadas em tráfego real.');
+  console.error('Feedback loop de confiabilidade falhou: regressões detectadas nos dados agregados de rota.');
   for (const failure of failures) {
     const reasons = failure.reasons?.join('; ') ?? failure.reason;
     console.error(`- ${failure.routeId}: ${reasons}`);
@@ -85,4 +86,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log(`Feedback loop de produção aprovado. Relatório: ${outputPath}`);
+console.log(`Feedback loop de confiabilidade aprovado. Relatório: ${displayPath(outputPath)}`);


### PR DESCRIPTION
### Motivation
- Evitar exposição acidental de caminhos absolutos e dar clareza de que os dados usados pelo gate são agregados/anonimizados em vez de tráfego real bruto. 
- Reduzir risco de commit involuntário de credenciais/segredos locais adicionando guardas em `.gitignore`.

### Description
- Adiciona entradas ao `.gitignore` para ` .env`, ` .env.*`, `!.env.example`, `*.pem` e `*.key` para prevenir commit acidental de material sensível. 
- Atualiza `scripts/run-production-feedback-gate.mjs` e `scripts/generate-engineering-health-panel.mjs` para serializar caminhos como relativos ao repositório usando `path.relative` e `displayPath`, além de ajustar mensagens para enfatizar dados agregados. 
- Sanitiza artefatos versionados em `artifacts/health/engineering-health-panel.json`, `artifacts/observability/production-feedback-report.latest.json` e `artifacts/observability/production-thresholds.v1.json` para usar caminhos relativos e texto que evita mencionar “tráfego real” bruto. 
- Atualiza documentação e CI para renomear/clarificar o gate como baseado em dados agregados (ajuste em `.github/workflows/ci.yml` e nos arquivos em `docs/`).

### Testing
- Executed `npm run lint` and it completed successfully. 
- Executed `npm run test` (monorepo workspace tests) and all test suites passed. 
- Ran `node scripts/run-production-feedback-gate.mjs` and it completed successfully, producing a report. 
- Attempted `node scripts/generate-engineering-health-panel.mjs` but it could not run in this environment due to missing artifact files (`packages/build/dist/performance-budget.json` and `artifacts/dora/metrics.latest.json`) so generation was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d411dcb84832db5e62d9eb0d61dc7)